### PR TITLE
fix issue #12 NullReferenceException

### DIFF
--- a/PhoenixSharp.Interfaces/IWebRequester.cs
+++ b/PhoenixSharp.Interfaces/IWebRequester.cs
@@ -37,7 +37,10 @@ namespace PhoenixSharp.Interfaces
             {
                 PostRequestAction(this);
             }
-            WebResponse.Dispose();
+            if (WebResponse != null)
+            {
+                WebResponse.Dispose();
+            }
         }
     }
 }

--- a/PhoenixSharp/Internal/Helpers/TaskHelpers.cs
+++ b/PhoenixSharp/Internal/Helpers/TaskHelpers.cs
@@ -1,0 +1,103 @@
+﻿// Copyright (c) Microsoft Corporation
+// All rights reserved.
+// 
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License.  You may obtain a copy
+// of the License at http://www.apache.org/licenses/LICENSE-2.0
+// 
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION ANY IMPLIED
+// WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A PARTICULAR PURPOSE,
+// MERCHANTABLITY OR NON-INFRINGEMENT.
+// 
+// See the Apache Version 2.0 License for specific language governing
+// permissions and limitations under the License.
+
+namespace PhoenixSharp.Internal.Helpers
+{
+    using System.Threading;
+    using System;
+    using System.Threading.Tasks;
+
+    internal static class TaskHelpers
+    {
+        internal static CancellationTokenSource CreateLinkedCancellationTokenSource(CancellationToken token)
+        {
+            return token.CanBeCanceled ? CancellationTokenSource.CreateLinkedTokenSource(token) : new CancellationTokenSource();
+        }
+
+        internal static Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout, string errorMessage)
+        {
+            return WithTimeout(task, timeout, errorMessage, CancellationToken.None);
+        }
+
+        internal static async Task<T> WithTimeout<T>(this Task<T> task, TimeSpan timeout, string errorMessage, CancellationToken token)
+        {
+            using (CancellationTokenSource cts = CreateLinkedCancellationTokenSource(token))
+            {
+                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+                {
+                    cts.Cancel();
+                    return await task;
+                }
+            }
+
+            // Ignore fault from task to avoid UnobservedTaskException
+            task.IgnoreFault();
+
+            if (token.IsCancellationRequested)
+            {
+                token.ThrowIfCancellationRequested();
+            }
+
+            throw new TimeoutException(string.Format("{0}. Timeout: {1}.", errorMessage, timeout));
+        }
+
+        internal static Task WithTimeout(this Task task, TimeSpan timeout, string errorMessage)
+        {
+            return WithTimeout(task, timeout, errorMessage, CancellationToken.None);
+        }
+
+        internal static async Task WithTimeout(this Task task, TimeSpan timeout, string errorMessage, CancellationToken token)
+        {
+            using (CancellationTokenSource cts = CreateLinkedCancellationTokenSource(token))
+            {
+                if (task == await Task.WhenAny(task, Task.Delay(timeout, cts.Token)))
+                {
+                    cts.Cancel();
+                    await task;
+                    return;
+                }
+            }
+
+            // Ignore fault from task to avoid UnobservedTaskException
+            task.IgnoreFault();
+
+            if (token.IsCancellationRequested)
+            {
+                token.ThrowIfCancellationRequested();
+            }
+
+            throw new TimeoutException(string.Format("{0}. Timeout: {1}.", errorMessage, timeout));
+        }
+
+        internal static void IgnoreFault(this Task task)
+        {
+            if (task.IsCompleted)
+            {
+                var ignored = task.Exception;
+            }
+            else
+            {
+                task.ContinueWith
+                    (t =>
+                    {
+                        var ignored = t.Exception;
+                    },
+                    TaskContinuationOptions.OnlyOnFaulted | TaskContinuationOptions.ExecuteSynchronously
+                    );
+            }
+        }
+    }
+
+}

--- a/PhoenixSharp/PhoenixSharp.csproj
+++ b/PhoenixSharp/PhoenixSharp.csproj
@@ -50,6 +50,7 @@
   <ItemGroup>
     <Compile Include="ClusterCredentials.cs" />
     <Compile Include="Internal\Extensions\StringExtensions.cs" />
+    <Compile Include="Internal\Helpers\TaskHelpers.cs" />
     <Compile Include="PhoenixClient.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Requester\GatewayWebRequester.cs" />

--- a/PhoenixSharp/Requester/VNetWebRequester.cs
+++ b/PhoenixSharp/Requester/VNetWebRequester.cs
@@ -19,8 +19,10 @@ namespace PhoenixSharp.Requester
     using System.Diagnostics;
     using System.IO;
     using System.Net;
+    using System.Threading;
     using System.Threading.Tasks;
     using Interfaces;
+    using PhoenixSharp.Internal.Helpers;
 
     /// <summary>
     /// 
@@ -75,32 +77,76 @@ namespace PhoenixSharp.Requester
                 }
             }
 
+            long remainingTime = options.TimeoutMillis;
             if (input != null)
             {
-                // seek to the beginning, so we copy everything in this buffer
-                input.Seek(0, SeekOrigin.Begin);
-                using (Stream req = httpWebRequest.GetRequestStream())
+                // expecting the caller to seek to the beginning or to the location where it needs to be copied from
+                Stream req = null;
+                try
                 {
-                    await input.CopyToAsync(req);
+                    req = await httpWebRequest.GetRequestStreamAsync().WithTimeout(
+                                                TimeSpan.FromMilliseconds(remainingTime),
+                                                "Waiting for RequestStream");
+
+                    remainingTime = options.TimeoutMillis - watch.ElapsedMilliseconds;
+                    if (remainingTime <= 0)
+                    {
+                        remainingTime = 0;
+                    }
+
+                    await input.CopyToAsync(req).WithTimeout(
+                                TimeSpan.FromMilliseconds(remainingTime),
+                                "Waiting for CopyToAsync",
+                                CancellationToken.None);
+                }
+                catch (TimeoutException)
+                {
+                    httpWebRequest.Abort();
+                    throw;
+                }
+                finally
+                {
+                    if (req != null)
+                    {
+                        req.Close();
+                    }
                 }
             }
+
             try
             {
-                var response = (await httpWebRequest.GetResponseAsync()) as HttpWebResponse;
+                remainingTime = options.TimeoutMillis - watch.ElapsedMilliseconds;
+                if (remainingTime <= 0)
+                {
+                    remainingTime = 0;
+                }
+
+                HttpWebResponse response = (HttpWebResponse)await httpWebRequest.GetResponseAsync().WithTimeout(
+                                                                TimeSpan.FromMilliseconds(remainingTime),
+                                                                "Waiting for GetResponseAsync");
                 return new Response()
                 {
                     WebResponse = response,
                     RequestLatency = watch.Elapsed
                 };
             }
-            catch (WebException we)
+            catch (Exception ex)
             {
-                var resp = we.Response as HttpWebResponse;
-                return new Response()
+                if (ex is WebException)
                 {
-                    WebResponse = resp,
-                    RequestLatency = watch.Elapsed
-                };
+                    WebException we = (WebException)ex;
+                    var resp = we.Response as HttpWebResponse;
+                    return new Response()
+                    {
+                        WebResponse = resp,
+                        RequestLatency = watch.Elapsed
+                    };
+                }
+                else
+                {
+                    httpWebRequest.Abort();
+                    throw;
+                }
             }
 
         }


### PR DESCRIPTION
1. RequestOptions.TimeoutMillis is not honored for Async calls on the
   HttpWebRequest. So calls to async calls need to timeout explicitly and
   abort the webrequest.
2. WebException returns as normal Response and will be decoded and
   thrown by PhoenixClient. Other exceptions will be thrown directly by
   WebRequester.
